### PR TITLE
fix(Due Date): Bill due date not displaying correctly

### DIFF
--- a/src/features/billSlice.js
+++ b/src/features/billSlice.js
@@ -227,7 +227,8 @@ const billSlice = createSlice({
                 bill.dueDate.forEach((dueDate, index) => {
                     // add a single bill with specific due date
                     // NOTE TO DO: CHANGE CURRENT YEAR FOR USER TO SELECT ANY YEAR AND SHOW BILLS ACCORDING TO YEAR
-                    if(new Date(dueDate).getMonth() === state.month && new Date(dueDate).getFullYear() === state.year) 
+                    // Add .replace(/-/g, '\/').replace(/T.+/, ''). to fix weird javascript date time zone difference
+                    if(new Date(dueDate.replace(/-/g, '\/').replace(/T.+/, '')).getMonth() === state.month && new Date(dueDate).getFullYear() === state.year) 
                     monthlyBillsList.push({...bill, dueDate: dueDate, paid: bill.paid[index], dueDateIndex: index});
                 });
             });      


### PR DESCRIPTION
Add a replace(/-/g, '\/') in setMonthly bills to return the correct date when sorting bills